### PR TITLE
Command setup example fixed ESM syntax error

### DIFF
--- a/apps/docs/pages/docs/command-file-setup.mdx
+++ b/apps/docs/pages/docs/command-file-setup.mdx
@@ -36,11 +36,11 @@ Here's an example `/ping` slash command which replies with "Pong!"
         export const data = {
             name: 'ping',
             description: 'Pong!',
-        },
+        }
 
         export function run({ interaction, client, handler }) {
             interaction.reply(`:ping_pong: Pong! ${client.ws.ping}ms`);
-        },
+        }
 
         export const options = {
             devOnly: true,
@@ -48,7 +48,7 @@ Here's an example `/ping` slash command which replies with "Pong!"
             userPermissions: ['Administrator', 'AddReactions'],
             botPermissions: ['Administrator', 'AddReactions'],
             deleted: false,
-        },
+        }
         ```
     </Tabs.Tab>
     <Tabs.Tab>

--- a/apps/docs/pages/docs/command-file-setup.mdx
+++ b/apps/docs/pages/docs/command-file-setup.mdx
@@ -58,11 +58,11 @@ Here's an example `/ping` slash command which replies with "Pong!"
         export const data: CommandData = {
             name: 'ping',
             description: 'Pong!',
-        },
+        }
 
         export function run({ interaction, client, handler }: SlashCommandProps) {
             interaction.reply(`:ping_pong: Pong! ${client.ws.ping}ms`);
-        },
+        }
 
         export const options: CommandOptions = {
             devOnly: true,
@@ -70,7 +70,7 @@ Here's an example `/ping` slash command which replies with "Pong!"
             userPermissions: ['Administrator', 'AddReactions'],
             botPermissions: ['Administrator', 'AddReactions'],
             deleted: false,
-        },
+        }
         ```
     </Tabs.Tab>
 
@@ -112,11 +112,11 @@ Here's an example `content` command which replies with the content of the target
         export const data = {
             name: 'content',
             type: CommandType.Message,
-        },
+        }
 
         export function run({ interaction, client, handler }) {
             interaction.reply(`The message is: ${interaction.targetMessage}`);
-        },
+        }
 
         export const options = {
             devOnly: true,
@@ -124,7 +124,7 @@ Here's an example `content` command which replies with the content of the target
             userPermissions: ['Administrator', 'AddReactions'],
             botPermissions: ['Administrator', 'AddReactions'],
             deleted: false,
-        },
+        }
         ```
     </Tabs.Tab>
     <Tabs.Tab>
@@ -134,11 +134,11 @@ Here's an example `content` command which replies with the content of the target
         export const data: CommandData = {
             name: 'content',
             type: CommandType.Message,
-        },
+        }
 
         export function run({ interaction, client, handler }: ContextMenuCommandProps) {
             interaction.reply(`The message is: ${interaction.targetMessage}`);
-        },
+        }
 
         export const options: CommandOptions = {
             devOnly: true,
@@ -146,7 +146,7 @@ Here's an example `content` command which replies with the content of the target
             userPermissions: ['Administrator', 'AddReactions'],
             botPermissions: ['Administrator', 'AddReactions'],
             deleted: false,
-        },
+        }
         ```
     </Tabs.Tab>
 


### PR DESCRIPTION
In the ESM command example i removed "," because it gives users a syntax error when copy-pasting