### PR TITLE
Updated docs

### DIFF
--- a/apps/docs/pages/docs/commandkit-setup.mdx
+++ b/apps/docs/pages/docs/commandkit-setup.mdx
@@ -99,7 +99,9 @@ This is a simple overview of how to set up CommandKit with all the available opt
 
 </Tabs>
 
-<Callout>Some Discord.js properties are only accessible using the correct intents.</Callout>
+<Callout type="warning">
+    Some Discord.js properties are only accessible using the correct intents.
+</Callout>
 
 ## CommandKit options
 

--- a/apps/docs/pages/docs/commandkit-setup.mdx
+++ b/apps/docs/pages/docs/commandkit-setup.mdx
@@ -107,7 +107,7 @@ This is a simple overview of how to set up CommandKit with all the available opt
 
 ### `client`
 
--   Type: [`Client`](https://discord.js.org/docs/packages/core/1.0.1/Client:Class)
+-   Type: [`Client`](https://old.discordjs.dev/#/docs/discord.js/main/class/Client)
 
 This is your Discord.js client object. This is required to register and handle application commands and events.
 

--- a/apps/docs/pages/docs/installation.mdx
+++ b/apps/docs/pages/docs/installation.mdx
@@ -12,7 +12,7 @@ npm install commandkit
 
 To install the development version of CommandKit, run the following command:
 
-```sh copy
+```sh npm2yarn copy
 npm install commandkit@dev
 ```
 


### PR DESCRIPTION
- Warning type for callout (commandkit-setup.mdx)
- npm2yarn for the development version installation
- Replaced module docs for Client with old discord.js docs