### PR TITLE
fix(get-paths): asynchronously load files and dirs

### DIFF
--- a/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
+++ b/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
@@ -69,10 +69,9 @@ export class CommandHandler {
 
     async #buildCommands() {
         const allowedExtensions = /\.(js|mjs|cjs|ts)$/i;
+        const paths = await getFilePaths(this.#data.commandsPath, true);
 
-        const commandFilePaths = getFilePaths(this.#data.commandsPath, true).filter((path) =>
-            allowedExtensions.test(path),
-        );
+        const commandFilePaths = paths.filter((path) => allowedExtensions.test(path));
 
         for (const commandFilePath of commandFilePaths) {
             const modulePath = toFileURL(commandFilePath);

--- a/packages/commandkit/src/handlers/event-handler/EventHandler.ts
+++ b/packages/commandkit/src/handlers/event-handler/EventHandler.ts
@@ -23,7 +23,7 @@ export class EventHandler {
     }
 
     async #buildEvents() {
-        const eventFolderPaths = getFolderPaths(this.#data.eventsPath);
+        const eventFolderPaths = await getFolderPaths(this.#data.eventsPath);
 
         for (const eventFolderPath of eventFolderPaths) {
             const eventName = eventFolderPath
@@ -32,10 +32,9 @@ export class EventHandler {
                 .pop() as string;
 
             const allowedExtensions = /\.(js|mjs|cjs|ts)$/i;
+            const eventPaths = await getFilePaths(eventFolderPath, true);
 
-            const eventFilePaths = getFilePaths(eventFolderPath, true).filter((path) =>
-                allowedExtensions.test(path),
-            );
+            const eventFilePaths = eventPaths.filter((path) => allowedExtensions.test(path));
 
             const eventObj = {
                 name: eventName,

--- a/packages/commandkit/src/handlers/validation-handler/ValidationHandler.ts
+++ b/packages/commandkit/src/handlers/validation-handler/ValidationHandler.ts
@@ -23,9 +23,8 @@ export class ValidationHandler {
     async #buildValidations() {
         const allowedExtensions = /\.(js|mjs|cjs|ts)$/i;
 
-        const validationFilePaths = getFilePaths(this.#data.validationsPath, true).filter((path) =>
-            allowedExtensions.test(path),
-        );
+        const validationPaths = await getFilePaths(this.#data.validationsPath, true);
+        const validationFilePaths = validationPaths.filter((path) => allowedExtensions.test(path));
 
         for (const validationFilePath of validationFilePaths) {
             const modulePath = toFileURL(validationFilePath);

--- a/packages/commandkit/src/types/index.ts
+++ b/packages/commandkit/src/types/index.ts
@@ -50,11 +50,9 @@ export enum CommandType {
 
 type LocaleString =
     | 'id'
-    | 'en-US'
-    | 'en-GB'
+    | `en-${'GB' | 'US'}`
     | 'bg'
-    | 'zh-CN'
-    | 'zh-TW'
+    | `zh-${'CN' | 'TW'}`
     | 'hr'
     | 'cs'
     | 'da'
@@ -112,6 +110,6 @@ export type CommandObject = {
 };
 
 export enum ReloadType {
-    'Developer' = 'dev',
-    'Global' = 'global',
+    Developer = 'dev',
+    Global = 'global',
 }

--- a/packages/commandkit/src/utils/get-paths.ts
+++ b/packages/commandkit/src/utils/get-paths.ts
@@ -1,12 +1,12 @@
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs/promises';
 
-export function getFilePaths(directory: string, nesting?: boolean): string[] {
+export async function getFilePaths(directory: string, nesting?: boolean): Promise<string[]> {
     let filePaths: string[] = [];
 
     if (!directory) return filePaths;
 
-    const files = fs.readdirSync(directory, { withFileTypes: true });
+    const files = await fs.readdir(directory, { withFileTypes: true });
 
     for (const file of files) {
         const filePath = path.join(directory, file.name);
@@ -16,19 +16,19 @@ export function getFilePaths(directory: string, nesting?: boolean): string[] {
         }
 
         if (nesting && file.isDirectory()) {
-            filePaths = [...filePaths, ...getFilePaths(filePath, true)];
+            filePaths = [...filePaths, ...(await getFilePaths(filePath, true))];
         }
     }
 
     return filePaths;
 }
 
-export function getFolderPaths(directory: string, nesting?: boolean): string[] {
+export async function getFolderPaths(directory: string, nesting?: boolean): Promise<string[]> {
     let folderPaths: string[] = [];
 
     if (!directory) return folderPaths;
 
-    const folders = fs.readdirSync(directory, { withFileTypes: true });
+    const folders = await fs.readdir(directory, { withFileTypes: true });
 
     for (const folder of folders) {
         const folderPath = path.join(directory, folder.name);
@@ -37,7 +37,7 @@ export function getFolderPaths(directory: string, nesting?: boolean): string[] {
             folderPaths.push(folderPath);
 
             if (nesting) {
-                folderPaths = [...folderPaths, ...getFolderPaths(folderPath, true)];
+                folderPaths = [...folderPaths, ...(await getFolderPaths(folderPath, true))];
             }
         }
     }


### PR DESCRIPTION
This PR updates functions inside `get-paths.ts` to asynchronously load the files. Since the other components that called these functions were already asynchronous, this update should not break anything.

On the side, I have also updated some typings.