### PR TITLE
Fix: Command handler

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
     "printWidth": 100,
     "tabWidth": 4,
     "singleQuote": true,
+    "semi": true,
     "arrowParens": "always"
 }

--- a/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
+++ b/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
@@ -171,7 +171,14 @@ export class CommandHandler {
                 (cmd) => cmd.data.name === interaction.commandName,
             );
 
-            if (!targetCommand) return;
+            if (!targetCommand) {
+                console.log(
+                    colors.yellow(
+                        `⏩ Ignoring: Command ${interaction.commandName} does not have a file`,
+                    ),
+                );
+                return;
+            }
 
             const { data, options, run, autocompleteRun, ...rest } = targetCommand;
 


### PR DESCRIPTION
# Changes
- Add semicolon in prettier config
- Command handler now give a warning if command file does not exist.
![image](https://github.com/underctrl-io/commandkit/assets/119097812/1e41ce08-a601-4fd8-a865-8395d8752c14)

