### PR TITLE
Guide changes

### DIFF
--- a/apps/docs/pages/guide/command-file-setup.mdx
+++ b/apps/docs/pages/guide/command-file-setup.mdx
@@ -162,6 +162,7 @@ Here's an example of how to use the `autocomplete` function:
 <Tabs items={['CommonJS', 'ESM', 'TypeScript']}>
     <Tabs.Tab>
         ```js filename="commands/Fun/pet.js" copy
+        const { SlashCommandBuilder } = require('discord.js');
         const pets = require('../data/pets.json');
 
         module.exports = {
@@ -202,6 +203,7 @@ Here's an example of how to use the `autocomplete` function:
     </Tabs.Tab>
     <Tabs.Tab>
         ```js filename="commands/Fun/pet.js" copy
+        import { SlashCommandBuilder } from 'discord.js';
         import pets from '../data/pets.json';
 
         export const data = new SlashCommandBuilder()
@@ -241,6 +243,7 @@ Here's an example of how to use the `autocomplete` function:
     <Tabs.Tab>
         ```ts filename="commands/Fun/pet.ts" copy
         import type { CommandData, AutocompleteProps, CommandOptions } from 'commandkit';
+        import { SlashCommandProps } from 'discord.js';
         import pets from '../data/pets.json';
 
         export const data = new SlashCommandBuilder()

--- a/apps/docs/pages/guide/command-file-setup.mdx
+++ b/apps/docs/pages/guide/command-file-setup.mdx
@@ -293,7 +293,7 @@ This property contains the command's structural information, and is required to 
 
 ### `run`
 
--   Type: `void`
+-   Type: `Function`
 
 -   Props Type: [`SlashCommandProps`](/docs/typedef/SlashCommandProps) | [`ContextMenuCommandProps`](/docs/typedef/ContextMenuCommandProps)
 
@@ -301,7 +301,7 @@ This function will be called when the command is executed.
 
 ### `autocomplete`
 
--   Type: `void`
+-   Type: `Function`
 -   Props Type: [`AutocompleteProps`](/docs/typedef/AutocompleteProps)
 
 This function will be called when an autocomplete interaction event is triggered for any option set as autocomplete in this command's `data` object.


### PR DESCRIPTION
- Used `Function` type instead of `void` because that's more descriptive, especially for beginners.
- Added missing `SlashCommandBuilder` imports for the guide's autocomplete examples.