### PR TITLE
Docs & CLI changes

### DIFF
--- a/apps/docs/pages/guide/command-file-setup.mdx
+++ b/apps/docs/pages/guide/command-file-setup.mdx
@@ -162,6 +162,7 @@ Here's an example of how to use the `autocomplete` function:
 <Tabs items={['CommonJS', 'ESM', 'TypeScript']}>
     <Tabs.Tab>
         ```js filename="commands/Fun/pet.js" copy
+        const { SlashCommandBuilder } = require('discord.js');
         const pets = require('../data/pets.json');
 
         module.exports = {
@@ -202,6 +203,7 @@ Here's an example of how to use the `autocomplete` function:
     </Tabs.Tab>
     <Tabs.Tab>
         ```js filename="commands/Fun/pet.js" copy
+        import { SlashCommandBuilder } from 'discord.js';
         import pets from '../data/pets.json';
 
         export const data = new SlashCommandBuilder()
@@ -241,6 +243,7 @@ Here's an example of how to use the `autocomplete` function:
     <Tabs.Tab>
         ```ts filename="commands/Fun/pet.ts" copy
         import type { CommandData, AutocompleteProps, CommandOptions } from 'commandkit';
+        import { SlashCommandBuilder } from 'discord.js';
         import pets from '../data/pets.json';
 
         export const data = new SlashCommandBuilder()

--- a/packages/commandkit/bin/common.mjs
+++ b/packages/commandkit/bin/common.mjs
@@ -76,7 +76,6 @@ export async function findCommandKitConfig(src) {
 
     for (const location of locations) {
         try {
-            const config = await loadConfigInner(location);
             foundConfigFiles.push(location);
         } catch (e) {
             continue;

--- a/packages/commandkit/bin/common.mjs
+++ b/packages/commandkit/bin/common.mjs
@@ -76,6 +76,7 @@ export async function findCommandKitConfig(src) {
 
     for (const location of locations) {
         try {
+            await loadConfigInner(location);
             foundConfigFiles.push(location);
         } catch (e) {
             continue;

--- a/packages/commandkit/bin/common.mjs
+++ b/packages/commandkit/bin/common.mjs
@@ -72,16 +72,24 @@ const possibleFileNames = [
 export async function findCommandKitConfig(src) {
     const cwd = process.cwd();
     const locations = src ? [join(cwd, src)] : possibleFileNames.map((name) => join(cwd, name));
+    const foundConfigFiles = [];
 
     for (const location of locations) {
         try {
-            return await loadConfigInner(location);
+            const config = await loadConfigInner(location);
+            foundConfigFiles.push(location);
         } catch (e) {
             continue;
         }
     }
 
-    panic('Could not locate commandkit config.');
+    if (foundConfigFiles.length > 1) {
+        panic(`Multiple configuration files found: ${foundConfigFiles.join(', ')}`);
+    } else if (foundConfigFiles.length === 0) {
+        panic('Could not locate CommandKit configuration file!');
+    }
+
+    return loadConfigInner(foundConfigFiles[0]);
 }
 
 async function loadConfigInner(target) {


### PR DESCRIPTION
- Added missing `SlashCommandBuilder` imports for the guide's autocomplete command examples.
- The CLI will now panic to the console if multiple CommandKit configuration files exist.