### PR TITLE
Use `process.emitWarning()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,17 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.10 - dev] - 2023-12-29
 
+### Fixed
+
+-   Typos during command load/reload in specific guild (REST).
+
+### Changed
+
+-   Use `process.emitWarning()` for warnings instead of regular console logs.
+-   Throw an error if a global command registration/deletion fails instead of just logging (for legacy command registation).
+
 ### Removed
 
 -   `guildOnly` from docs examples. Closes [#42](https://github.com/underctrl-io/commandkit/issues/42)
 -   `guildOnly` deprecation warning.
+-   Emojis from logs, warnings, and errors.

--- a/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
+++ b/packages/commandkit/src/handlers/command-handler/CommandHandler.ts
@@ -32,9 +32,9 @@ export class CommandHandler {
         const devOnlyCommands = this.#data.commands.filter((cmd) => cmd.options?.devOnly);
 
         if (devOnlyCommands.length && !this.#data.devGuildIds.length) {
-            console.log(
+            process.emitWarning(
                 colors.yellow(
-                    'ℹ️ Warning: You have commands marked as "devOnly", but "devGuildIds" have not been set.',
+                    'You have commands marked as "devOnly", but "devGuildIds" have not been set.',
                 ),
             );
         }
@@ -44,9 +44,9 @@ export class CommandHandler {
             !this.#data.devUserIds.length &&
             !this.#data.devRoleIds.length
         ) {
-            console.log(
+            process.emitWarning(
                 colors.yellow(
-                    'ℹ️ Warning: You have commands marked as "devOnly", but "devUserIds" or "devRoleIds" have not been set.',
+                    'You have commands marked as "devOnly", but "devUserIds" or "devRoleIds" have not been set.',
                 ),
             );
         }
@@ -97,36 +97,36 @@ export class CommandHandler {
             }
 
             if (!commandObj.data) {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Command ${compactFilePath} does not export "data".`,
+                        `Ignoring: Command file ${compactFilePath} does not export "data".`,
                     ),
                 );
                 continue;
             }
 
             if (!commandObj.data.name) {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Command ${compactFilePath} does not export "data.name".`,
+                        `Ignoring: Command file ${compactFilePath} does not export "data.name".`,
                     ),
                 );
                 continue;
             }
 
             if (!commandObj.run) {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Command ${commandObj.data.name} does not export "run".`,
+                        `Ignoring: Command file ${commandObj.data.name} does not export "run".`,
                     ),
                 );
                 continue;
             }
 
             if (typeof commandObj.run !== 'function') {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Command ${commandObj.data.name} does not export "run" as a function.`,
+                        `Ignoring: Command file ${commandObj.data.name} does not export "run" as a function.`,
                     ),
                 );
                 continue;
@@ -241,7 +241,9 @@ export class CommandHandler {
     async reloadCommands(type?: ReloadOptions) {
         if (!this.#data.commandsPath) {
             throw new Error(
-                'Cannot reload commands as "commandsPath" was not provided when instantiating CommandKit.',
+                colors.red(
+                    'Cannot reload commands as "commandsPath" was not provided when instantiating CommandKit.',
+                ),
             );
         }
 

--- a/packages/commandkit/src/handlers/command-handler/functions/loadCommandsWithRest.ts
+++ b/packages/commandkit/src/handlers/command-handler/functions/loadCommandsWithRest.ts
@@ -45,7 +45,7 @@ export default async function loadCommandsWithRest(props: LoadCommandsWithRestPr
                 props.type,
             );
         } else {
-            throw new Error(colors.red(`❌ Cannot reload commands when client is not ready.`));
+            throw new Error(colors.red(`Cannot reload commands when client is not ready.`));
         }
     } else {
         props.client.once('ready', async (c) => {
@@ -99,20 +99,16 @@ async function loadGlobalCommands(
     await client.application.commands
         .set(requestBody as ApplicationCommandDataResolvable[])
         .catch((error) => {
-            console.log(
+            throw new Error(
                 colors.red(
-                    `❌ Error ${
-                        reloading ? 'reloading' : 'loading'
-                    } global application commands.\n`,
+                    `Error ${reloading ? 'reloading' : 'loading'} global application commands.\n`,
                 ),
+                error,
             );
-            throw new Error(error);
         });
 
     console.log(
-        colors.green(
-            `✅ ${reloading ? 'Reloaded' : 'Loaded'} ${requestBody.length} global commands.`,
-        ),
+        colors.green(`${reloading ? 'Reloaded' : 'Loaded'} ${requestBody.length} global commands.`),
     );
 }
 
@@ -136,10 +132,10 @@ async function loadDevCommands(
             client.guilds.cache.get(guildId) || (await client.guilds.fetch(guildId));
 
         if (!targetGuild) {
-            console.log(
-                `Couldn't ${
-                    reloading ? 'reloading' : 'loading'
-                } commands in guild "${targetGuild}" - guild doesn't exist or client isn't part of the guild.`,
+            process.emitWarning(
+                `Cannot ${
+                    reloading ? 'reload' : 'load'
+                } commands in guild "${guildId}" - guild doesn't exist or client isn't part of the guild.`,
             );
 
             continue;
@@ -148,21 +144,21 @@ async function loadDevCommands(
         await targetGuild.commands
             .set(requestBody as ApplicationCommandDataResolvable[])
             .catch((error) => {
-                console.log(
+                throw new Error(
                     colors.red(
-                        `❌ Error ${
+                        `Error ${
                             reloading ? 'reloading' : 'loading'
                         } developer application commands in guild "${
                             targetGuild?.name || guildId
                         }".\n`,
                     ),
+                    error,
                 );
-                throw new Error(error);
             });
 
         console.log(
             colors.green(
-                `✅ ${reloading ? 'Reloaded' : 'Loaded'} ${
+                `${reloading ? 'Reloaded' : 'Loaded'} ${
                     requestBody.length
                 } developer commands in guild "${targetGuild.name}".`,
             ),

--- a/packages/commandkit/src/handlers/command-handler/functions/registerCommands.ts
+++ b/packages/commandkit/src/handlers/command-handler/functions/registerCommands.ts
@@ -28,7 +28,7 @@ export default async function registerCommands(props: RegisterCommandProps) {
         if (props.client.isReady()) {
             await handleRegistration(props.client, props.commands, props.devGuildIds, props.type);
         } else {
-            throw new Error(colors.red(`❌ Cannot reload commands when client is not ready.`));
+            throw new Error(colors.red(`Cannot reload commands when client is not ready.`));
         }
     } else {
         props.client.once('ready', async (c) => {
@@ -68,20 +68,20 @@ async function registerGlobalCommands(client: Client<true>, commands: CommandFil
         // <!-- Delete global command -->
         if (command.options?.deleted) {
             if (!targetCommand) {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Command "${command.data.name}" is globally marked as deleted.`,
+                        `Ignoring: Command "${command.data.name}" is globally marked as deleted.`,
                     ),
                 );
             } else {
                 await targetCommand.delete().catch((error) => {
-                    console.log(
-                        colors.red(`❌ Failed to delete command "${command.data.name}" globally.`),
+                    throw new Error(
+                        colors.red(`Failed to delete command "${command.data.name}" globally.\n`),
+                        error,
                     );
-                    console.error(error);
                 });
 
-                console.log(colors.green(`🚮 Deleted command "${command.data.name}" globally.`));
+                console.log(colors.green(`Deleted command "${command.data.name}" globally.`));
             }
 
             continue;
@@ -95,15 +95,13 @@ async function registerGlobalCommands(client: Client<true>, commands: CommandFil
                 await targetCommand
                     .edit(command.data as Partial<ApplicationCommandData>)
                     .catch((error) => {
-                        console.log(
-                            colors.red(
-                                `❌ Failed to edit command "${command.data.name}" globally.`,
-                            ),
+                        throw new Error(
+                            colors.red(`Failed to edit command "${command.data.name}" globally.\n`),
+                            error,
                         );
-                        console.error(error);
                     });
 
-                console.log(colors.green(`✅ Edited command "${command.data.name}" globally.`));
+                console.log(colors.green(`Edited command "${command.data.name}" globally.`));
 
                 continue;
             }
@@ -115,13 +113,13 @@ async function registerGlobalCommands(client: Client<true>, commands: CommandFil
         await appCommandsManager
             .create(command.data as ApplicationCommandDataResolvable)
             .catch((error) => {
-                console.log(
-                    colors.red(`❌ Failed to register command "${command.data.name}" globally.`),
+                throw new Error(
+                    colors.red(`Failed to register command "${command.data.name}" globally.\n`),
+                    error,
                 );
-                console.error(error);
             });
 
-        console.log(colors.green(`✅ Registered command "${command.data.name}" globally.`));
+        console.log(colors.green(`Registered command "${command.data.name}" globally.`));
     }
 }
 
@@ -136,9 +134,9 @@ async function registerDevCommands(
         const guild = client.guilds.cache.get(guildId) || (await client.guilds.fetch(guildId));
 
         if (!guild) {
-            console.log(
+            process.emitWarning(
                 colors.yellow(
-                    `⏩ Ignoring: Guild ${guildId} does not exist or client isn't in this guild.`,
+                    `Ignoring: Guild ${guildId} doesn't exist or client isn't part of the guild.`,
                 ),
             );
             continue;
@@ -163,24 +161,24 @@ async function registerDevCommands(
             // <!-- Delete dev command -->
             if (command.options?.deleted) {
                 if (!targetCommand) {
-                    console.log(
+                    process.emitWarning(
                         colors.yellow(
-                            `⏩ Ignoring: Command "${command.data.name}" is marked as deleted for ${guildCommands.guild.name}.`,
+                            `Ignoring: Command "${command.data.name}" is marked as deleted in ${guildCommands.guild.name}.`,
                         ),
                     );
                 } else {
                     await targetCommand.delete().catch((error) => {
-                        console.log(
+                        throw new Error(
                             colors.red(
-                                `❌ Failed to delete command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                                `Failed to delete command "${command.data.name}" in ${guildCommands.guild.name}.`,
                             ),
+                            error,
                         );
-                        console.error(error);
                     });
 
                     console.log(
                         colors.green(
-                            `🚮 Deleted command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                            `Deleted command "${command.data.name}" in ${guildCommands.guild.name}.`,
                         ),
                     );
                 }
@@ -196,17 +194,17 @@ async function registerDevCommands(
                     await targetCommand
                         .edit(command.data as Partial<ApplicationCommandData>)
                         .catch((error) => {
-                            console.log(
+                            throw new Error(
                                 colors.red(
-                                    `❌ Failed to edit command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                                    `Failed to edit command "${command.data.name}" in ${guildCommands.guild.name}.\n`,
                                 ),
+                                error,
                             );
-                            console.error(error);
                         });
 
                     console.log(
                         colors.green(
-                            `✅ Edited command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                            `Edited command "${command.data.name}" in ${guildCommands.guild.name}.`,
                         ),
                     );
 
@@ -220,17 +218,17 @@ async function registerDevCommands(
             await guildCommands
                 .create(command.data as ApplicationCommandDataResolvable)
                 .catch((error) => {
-                    console.log(
+                    throw new Error(
                         colors.red(
-                            `❌ Failed to register command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                            `Failed to register command "${command.data.name}" in ${guildCommands.guild.name}.\n`,
                         ),
+                        error,
                     );
-                    console.error(error);
                 });
 
             console.log(
                 colors.green(
-                    `✅ Registered command "${command.data.name}" in ${guildCommands.guild.name}.`,
+                    `Registered command "${command.data.name}" in ${guildCommands.guild.name}.`,
                 ),
             );
         }

--- a/packages/commandkit/src/handlers/event-handler/EventHandler.ts
+++ b/packages/commandkit/src/handlers/event-handler/EventHandler.ts
@@ -62,9 +62,9 @@ export class EventHandler {
                 const compactFilePath = eventFilePath.split(process.cwd())[1] || eventFilePath;
 
                 if (typeof eventFunction !== 'function') {
-                    console.log(
+                    process.emitWarning(
                         colors.yellow(
-                            `⏩ Ignoring: Event ${compactFilePath} does not export a function.`,
+                            `Ignoring: Event file ${compactFilePath} does not export a function.`,
                         ),
                     );
                     continue;
@@ -99,7 +99,9 @@ export class EventHandler {
     async reloadEvents(commandHandler?: CommandHandler) {
         if (!this.#data.eventsPath) {
             throw new Error(
-                'Cannot reload events as "eventsPath" was not provided when instantiating CommandKit.',
+                colors.red(
+                    'Cannot reload events as "eventsPath" was not provided when instantiating CommandKit.',
+                ),
             );
         }
 

--- a/packages/commandkit/src/handlers/validation-handler/ValidationHandler.ts
+++ b/packages/commandkit/src/handlers/validation-handler/ValidationHandler.ts
@@ -48,9 +48,9 @@ export class ValidationHandler {
                 validationFilePath.split(process.cwd())[1] || validationFilePath;
 
             if (typeof validationFunction !== 'function') {
-                console.log(
+                process.emitWarning(
                     colors.yellow(
-                        `⏩ Ignoring: Validation ${compactFilePath} does not export a function.`,
+                        `Ignoring: Validation file ${compactFilePath} does not export a function.`,
                     ),
                 );
                 continue;
@@ -69,7 +69,9 @@ export class ValidationHandler {
     async reloadValidations() {
         if (!this.#data.validationsPath) {
             throw new Error(
-                'Cannot reload validations as "validationsPath" was not provided when instantiating CommandKit.',
+                colors.red(
+                    'Cannot reload validations as "validationsPath" was not provided when instantiating CommandKit.',
+                ),
             );
         }
 

--- a/packages/commandkit/tests/src/index.ts
+++ b/packages/commandkit/tests/src/index.ts
@@ -1,6 +1,6 @@
 import { CommandKit } from '../../src/index';
 import { Client } from 'discord.js';
-require('dotenv').config();
+// require('dotenv').config();
 
 const client = new Client({
     intents: ['Guilds', 'GuildMembers', 'GuildMessages', 'MessageContent'],
@@ -11,8 +11,8 @@ new CommandKit({
     commandsPath: `${__dirname}/commands`,
     eventsPath: `${__dirname}/events`,
     validationsPath: `${__dirname}/validations`,
-    devGuildIds: process.env.DEV_GUILD_ID?.split(',') ?? [],
-    devUserIds: process.env.DEV_USER_ID?.split(',') ?? [],
+    // devGuildIds: process.env.DEV_GUILD_ID?.split(',') ?? [],
+    // devUserIds: process.env.DEV_USER_ID?.split(',') ?? [],
     bulkRegister: true,
 });
 


### PR DESCRIPTION
This PR primarily introduces the use of `process.emitWarning()` (where relevant) instead of the regular `console.log` as it allows warnings to be caught and suppressed.