### PR TITLE
build: minify for optimization

### DIFF
--- a/packages/commandkit/bin/build.mjs
+++ b/packages/commandkit/bin/build.mjs
@@ -9,7 +9,7 @@ import ora from 'ora';
 export async function bootstrapProductionBuild(config) {
     const {
         sourcemap = false,
-        minify = false,
+        minify = true,
         outDir = 'dist',
         antiCrash = true,
         src,

--- a/packages/commandkit/tsup.config.ts
+++ b/packages/commandkit/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
     format: ['cjs', 'esm'],
     entry: ['./src/index.ts'],
+    minify: true,
     dts: true,
     shims: true,
     skipNodeModulesBundle: true,


### PR DESCRIPTION
- For building the CommandKit package, I've enabled tsup's `minify` option. This results in a much smaller build, ideal for publishing to npm.
- Additionally, this option is now enabled by default in the CommandKit CLI's `build` command.