### PR TITLE
docs: update cooldowns validation example

### DIFF
--- a/apps/docs/pages/guide/validation-file-setup.mdx
+++ b/apps/docs/pages/guide/validation-file-setup.mdx
@@ -15,7 +15,7 @@ Validation functions are called on every command trigger, so it's important to k
 <Tabs items={['CommonJS', 'ESM', 'TypeScript']}>
     <Tabs.Tab label="CommonJS">
         ```js filename="validations/cooldowns.js" copy
-        const cooldowns = require('../cooldowns-cache');
+        const cooldowns = new Set();
 
         module.exports = ({ interaction, commandObj, handler }) => {
             if (cooldowns.has(`${interaction.user.id}-${commandObj.data.name}`)) {
@@ -32,7 +32,7 @@ Validation functions are called on every command trigger, so it's important to k
 
     <Tabs.Tab label="ESM">
         ```js filename="validations/cooldowns.js" copy
-        import cooldowns from '../cooldowns-cache';
+        const cooldowns = new Set();
 
         export default function ({ interaction, commandObj, handler }) {
             if (cooldowns.has(`${interaction.user.id}-${commandObj.data.name}`)) {
@@ -50,7 +50,7 @@ Validation functions are called on every command trigger, so it's important to k
     <Tabs.Tab label="TypeScript">
         ```ts filename="validations/cooldowns.ts" copy
         import type { ValidationProps } from 'commandkit';
-        import cooldowns from '../cooldowns-cache';
+        const cooldowns = new Set();
 
         export default function ({ interaction, commandObj, handler }: ValidationProps) {
             if (cooldowns.has(`${interaction.user.id}-${commandObj.data.name}`)) {


### PR DESCRIPTION
In this PR, I have updated the guide for validations. I used a `Set` variable directly instead of importing from the cache file, which is less confusing for individuals reading the guide.