### PR TITLE
Update command loader

### DIFF
--- a/apps/test-bot/src/app/commands/(general)/(animal)/cat.ts
+++ b/apps/test-bot/src/app/commands/(general)/(animal)/cat.ts
@@ -1,6 +1,6 @@
 import type {
-  CommandData,
   ChatInputCommand,
+  CommandData,
   MessageCommand,
   MessageContextMenuCommand,
 } from 'commandkit';
@@ -12,7 +12,7 @@ import {
 
 export const command: CommandData = {
   name: 'cat',
-  description: 'cat command',
+  // description: 'cat command',
   integration_types: [
     ApplicationIntegrationType.GuildInstall,
     ApplicationIntegrationType.UserInstall,

--- a/packages/commandkit/src/app/handlers/AppCommandHandler.ts
+++ b/packages/commandkit/src/app/handlers/AppCommandHandler.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationCommandType,
   AutocompleteInteraction,
   Awaitable,
   Collection,
@@ -679,7 +680,7 @@ export class AppCommandHandler {
           data: {
             command: {
               name: command.name,
-              description: `${command.name} commands`,
+              description: `${command.name} command`,
               type: 1,
             },
           },
@@ -695,6 +696,13 @@ export class AppCommandHandler {
         throw new Error(
           `Invalid export for command ${command.name}: no command definition found`,
         );
+      }
+
+      if (
+        commandFileData.command.type === ApplicationCommandType.ChatInput &&
+        !commandFileData.command.description
+      ) {
+        commandFileData.command.description = `${command.name} command`;
       }
 
       let handlerCount = 0;

--- a/packages/commandkit/src/app/handlers/AppCommandHandler.ts
+++ b/packages/commandkit/src/app/handlers/AppCommandHandler.ts
@@ -699,7 +699,8 @@ export class AppCommandHandler {
       }
 
       if (
-        commandFileData.command.type === ApplicationCommandType.ChatInput &&
+        (!commandFileData.command.type ||
+          commandFileData.command.type === ApplicationCommandType.ChatInput) &&
         !commandFileData.command.description
       ) {
         commandFileData.command.description = `${command.name} command`;

--- a/packages/commandkit/src/types.ts
+++ b/packages/commandkit/src/types.ts
@@ -6,6 +6,10 @@ import {
 } from 'discord.js';
 import type { CommandKit } from './CommandKit';
 
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
 /**
  * Options for instantiating a CommandKit handler.
  */
@@ -40,6 +44,9 @@ export interface CommandContext<
 /**
  * Represents a command that can be executed by CommandKit.
  */
-export type CommandData = RESTPostAPIApplicationCommandsJSONBody & {
-  guilds?: string[];
-};
+export type CommandData = Prettify<
+  Omit<RESTPostAPIApplicationCommandsJSONBody, 'description'> & {
+    description?: string;
+    guilds?: string[];
+  }
+>;


### PR DESCRIPTION
- Allow optional description in `CommandData` type
- Set fallback description for chat input commands if none provided
- Use `CommandData` type internally instead of `SlashCommandBuilder` to better reflect external use
- Fix loaded commands guild property not using property from `commandFileData.command.guilds`
- Add type safety for imported command  + command property/methods validators