### PR TITLE
feat: introduce COMMANDKIT_CWD constant for consistent working directory reference

### DIFF
--- a/packages/commandkit/env.cjs
+++ b/packages/commandkit/env.cjs
@@ -3,11 +3,13 @@ const {
   COMMANDKIT_IS_CLI,
   COMMANDKIT_IS_DEV,
   COMMANDKIT_IS_TEST,
-} = require('commandkit');
+  COMMANDKIT_CWD,
+} = require('./dist/utils/constants.js');
 
 module.exports = {
   COMMANDKIT_BOOTSTRAP_MODE,
   COMMANDKIT_IS_CLI,
   COMMANDKIT_IS_DEV,
   COMMANDKIT_IS_TEST,
+  COMMANDKIT_CWD,
 };

--- a/packages/commandkit/env.d.ts
+++ b/packages/commandkit/env.d.ts
@@ -3,4 +3,5 @@ export {
   COMMANDKIT_IS_CLI,
   COMMANDKIT_IS_DEV,
   COMMANDKIT_IS_TEST,
-} from 'commandkit';
+  COMMANDKIT_CWD,
+} from './dist/utils/constants';

--- a/packages/commandkit/src/cli/build.ts
+++ b/packages/commandkit/src/cli/build.ts
@@ -8,6 +8,7 @@ import { rimraf } from 'rimraf';
 import { performTypeCheck } from './type-checker';
 import { copyLocaleFiles } from './common';
 import { MaybeArray } from '../components';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 /**
  * @private
@@ -51,7 +52,7 @@ export async function buildApplication({
   const config = await loadConfigFile(configPath);
 
   if (!isDev && !config?.typescript?.ignoreBuildErrors) {
-    await performTypeCheck(configPath || process.cwd());
+    await performTypeCheck(configPath || COMMANDKIT_CWD);
   }
 
   const pluginRuntime = new CompilerPluginRuntime(
@@ -121,7 +122,11 @@ export async function buildApplication({
     });
 
     await copyLocaleFiles('src', dest);
-    await injectEntryFile(configPath || process.cwd(), !!isDev, config.distDir);
+    await injectEntryFile(
+      configPath || COMMANDKIT_CWD,
+      !!isDev,
+      config.distDir,
+    );
   } catch (error) {
     console.error('Build failed:', error);
     if (error instanceof Error) {

--- a/packages/commandkit/src/cli/common.ts
+++ b/packages/commandkit/src/cli/common.ts
@@ -5,6 +5,7 @@ import colors from '../utils/colors';
 import { ResolvedCommandKitConfig } from '../config/utils';
 import { generateTypesPackage } from '../utils/types-package';
 import { execSync } from 'node:child_process';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 let ts: typeof import('typescript') | undefined;
 
@@ -44,21 +45,6 @@ export function panic(message: any): never {
  * @private
  * @internal
  */
-export function findPackageJSON() {
-  const cwd = process.cwd();
-  const target = join(cwd, 'package.json');
-
-  if (!fs.existsSync(target)) {
-    panic('Could not find package.json in current directory.');
-  }
-
-  return JSON.parse(fs.readFileSync(target, 'utf8'));
-}
-
-/**
- * @private
- * @internal
- */
 async function ensureTypeScript(target: string) {
   const isTypeScript = /\.(c|m)?tsx?$/.test(target);
 
@@ -89,7 +75,7 @@ function detectPackageManager() {
   };
 
   for (const [lockfile, manager] of Object.entries(lockfiles)) {
-    if (fs.existsSync(join(process.cwd(), lockfile))) {
+    if (fs.existsSync(join(COMMANDKIT_CWD, lockfile))) {
       packageManager = manager;
       break;
     }
@@ -118,7 +104,7 @@ export async function loadTypeScript(e?: string) {
         const prefix = packageManager === 'deno' ? 'npm:' : '';
         execSync(`${packageManager} add -D ${prefix}typescript`, {
           stdio: 'inherit',
-          cwd: process.cwd(),
+          cwd: COMMANDKIT_CWD,
         });
 
         console.log(
@@ -169,7 +155,7 @@ export async function loadConfigFileFromPath(
 
     await generateTypesPackage();
 
-    const nodeModulesPath = process.cwd();
+    const nodeModulesPath = COMMANDKIT_CWD;
 
     const tmpFile = join(nodeModulesPath, 'compiled-commandkit.config.mjs');
 
@@ -223,8 +209,8 @@ export function erase(dir: string) {
  * @internal
  */
 export async function copyLocaleFiles(_from: string, _to: string) {
-  const resolvedFrom = join(process.cwd(), _from);
-  const resolvedTo = join(process.cwd(), _to);
+  const resolvedFrom = join(COMMANDKIT_CWD, _from);
+  const resolvedTo = join(COMMANDKIT_CWD, _to);
 
   const localePaths = ['app/locales'];
   const srcLocalePaths = localePaths.map((path) => join(resolvedFrom, path));

--- a/packages/commandkit/src/cli/development.ts
+++ b/packages/commandkit/src/cli/development.ts
@@ -9,7 +9,7 @@ import colors from '../utils/colors';
 import { ChildProcess } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { randomUUID } from 'node:crypto';
-import { HMREventType } from '../utils/constants';
+import { COMMANDKIT_CWD, HMREventType } from '../utils/constants';
 import { findEntrypoint } from './common';
 
 /**
@@ -55,7 +55,7 @@ const isEventSource = (p: string) =>
 export async function bootstrapDevelopmentServer(configPath?: string) {
   process.env.COMMANDKIT_BOOTSTRAP_MODE = 'development';
   const start = performance.now();
-  const cwd = configPath || process.cwd();
+  const cwd = configPath || COMMANDKIT_CWD;
   const configPaths = getPossibleConfigPaths(cwd);
 
   const watcher = watch([join(cwd, 'src'), ...configPaths], {

--- a/packages/commandkit/src/cli/generators.ts
+++ b/packages/commandkit/src/cli/generators.ts
@@ -3,8 +3,9 @@ import { join } from 'path';
 import { panic } from './common';
 import { existsSync } from 'fs';
 import colors from '../utils/colors';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
-const BASE_PATH = process.cwd();
+const BASE_PATH = COMMANDKIT_CWD;
 const COMMANDS_DIR = join(BASE_PATH, 'src/app/commands');
 const EVENTS_DIR = join(BASE_PATH, 'src/app/events');
 
@@ -13,7 +14,7 @@ const EVENTS_DIR = join(BASE_PATH, 'src/app/events');
  * @internal
  */
 const formatPath = (path: string) =>
-  path.replace(process.cwd(), '.').replace(/\\/g, '/');
+  path.replace(COMMANDKIT_CWD, '.').replace(/\\/g, '/');
 
 /**
  * @private

--- a/packages/commandkit/src/cli/information.ts
+++ b/packages/commandkit/src/cli/information.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { version as commandkitVersion } from '../version';
 import fs from 'node:fs';
 import path from 'node:path';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 /**
  * @private
@@ -65,11 +66,11 @@ function findPackageVersion(packageName: string) {
   } catch (e) {
     try {
       const basePaths = [
-        path.join(process.cwd(), 'node_modules', packageName),
-        path.join(process.cwd(), '..', '..', 'node_modules', packageName),
-        path.join(process.cwd(), '..', '..', '.pnpm', packageName),
+        path.join(COMMANDKIT_CWD, 'node_modules', packageName),
+        path.join(COMMANDKIT_CWD, '..', '..', 'node_modules', packageName),
+        path.join(COMMANDKIT_CWD, '..', '..', '.pnpm', packageName),
         path.join(
-          process.cwd(),
+          COMMANDKIT_CWD,
           '..',
           '..',
           'node_modules',
@@ -89,7 +90,7 @@ function findPackageVersion(packageName: string) {
       }
 
       const nodeModulesPath = path.join(
-        process.cwd(),
+        COMMANDKIT_CWD,
         '..',
         '..',
         'node_modules',

--- a/packages/commandkit/src/cli/init.ts
+++ b/packages/commandkit/src/cli/init.ts
@@ -9,6 +9,7 @@ import {
   isCompilerPlugin,
 } from '../plugins';
 import { panic } from './common';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 /**
  * Creates a command line interface for CommandKit.
@@ -142,7 +143,7 @@ export async function bootstrapCommandkitCLI(
       }
     });
 
-  const types = join(process.cwd(), 'node_modules', 'commandkit-types');
+  const types = join(COMMANDKIT_CWD, 'node_modules', 'commandkit-types');
 
   if (!existsSync(types)) {
     await mkdir(types, { recursive: true }).catch(() => {});

--- a/packages/commandkit/src/cli/production.ts
+++ b/packages/commandkit/src/cli/production.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { loadConfigFile } from '../config/loader';
 import { createAppProcess } from './app-process';
 import { existsSync } from 'fs';
@@ -6,6 +5,7 @@ import { findEntrypoint, panic } from './common';
 import { buildApplication } from './build';
 import { CompilerPlugin, isCompilerPlugin } from '../plugins';
 import { createSpinner } from './utils';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 /**
  * @private
@@ -13,7 +13,7 @@ import { createSpinner } from './utils';
  */
 export async function bootstrapProductionServer(configPath?: string) {
   process.env.COMMANDKIT_BOOTSTRAP_MODE = 'production';
-  const cwd = configPath || process.cwd();
+  const cwd = configPath || COMMANDKIT_CWD;
   const config = await loadConfigFile(cwd);
   const mainFile = findEntrypoint(config.distDir);
 
@@ -32,7 +32,7 @@ export async function bootstrapProductionServer(configPath?: string) {
  */
 export async function createProductionBuild(configPath?: string) {
   process.env.COMMANDKIT_BOOTSTRAP_MODE = 'production';
-  const cwd = configPath || process.cwd();
+  const cwd = configPath || COMMANDKIT_CWD;
   const config = await loadConfigFile(cwd);
 
   const spinner = await createSpinner(

--- a/packages/commandkit/src/config/loader.ts
+++ b/packages/commandkit/src/config/loader.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { loadConfigFileFromPath } from '../cli/common';
 import { getConfig } from './config';
+import { COMMANDKIT_CWD } from '../utils/constants';
 
 const CONFIG_FILE_NAMES = [
   'commandkit.config.js',
@@ -41,7 +42,7 @@ let loadedConfig: ReturnType<typeof getConfig> | null = null;
  * Load the configuration file from the given entrypoint.
  * @param entrypoint The entrypoint to load the configuration file from. Defaults to the current working directory.
  */
-export async function loadConfigFile(entrypoint = process.cwd()) {
+export async function loadConfigFile(entrypoint = COMMANDKIT_CWD) {
   if (loadedConfig) return loadedConfig;
   const filePath = findConfigFile(entrypoint);
   if (!filePath) return getConfig();

--- a/packages/commandkit/src/utils/constants.ts
+++ b/packages/commandkit/src/utils/constants.ts
@@ -1,4 +1,9 @@
 /**
+ * The current working directory of the CommandKit instance.
+ */
+export const COMMANDKIT_CWD = process.env.COMMANDKIT_CWD || process.cwd();
+
+/**
  * Indicates whether CommandKit is running in development mode.
  */
 export const COMMANDKIT_IS_DEV = process.env.COMMANDKIT_IS_DEV === 'true';

--- a/packages/commandkit/src/utils/types-package.ts
+++ b/packages/commandkit/src/utils/types-package.ts
@@ -1,13 +1,13 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { COMMANDKIT_IS_DEV } from './constants';
+import { COMMANDKIT_CWD, COMMANDKIT_IS_DEV } from './constants';
 import { existsSync } from 'node:fs';
 
 /**
  * @private
  */
 export async function generateTypesPackage(force = false) {
-  const location = join(process.cwd(), 'node_modules', 'commandkit-types');
+  const location = join(COMMANDKIT_CWD, 'node_modules', 'commandkit-types');
   if (!COMMANDKIT_IS_DEV && !force) return location;
   const packageJSON = join(location, 'package.json');
   const index = join(location, 'index.js');
@@ -58,7 +58,7 @@ export async function rewriteCommandDeclaration(data: string) {
     export {};
 `;
 
-  const location = join(process.cwd(), 'node_modules', 'commandkit-types');
+  const location = join(COMMANDKIT_CWD, 'node_modules', 'commandkit-types');
 
   if (!existsSync(location)) return;
 

--- a/packages/commandkit/src/utils/utilities.ts
+++ b/packages/commandkit/src/utils/utilities.ts
@@ -1,8 +1,11 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { COMMANDKIT_IS_CLI, COMMANDKIT_IS_DEV } from './constants';
+import {
+  COMMANDKIT_CWD,
+  COMMANDKIT_IS_CLI,
+  COMMANDKIT_IS_DEV,
+} from './constants';
 import { getConfig } from '../config/config';
-import { eventWorkerContext } from '../app/events/EventWorkerContext';
 
 let appDir: string | null = null;
 let currentDir: string | null = null;
@@ -26,9 +29,9 @@ function getSrcDir() {
 export function getCurrentDirectory(): string {
   if (currentDir) return currentDir;
   const src = getSrcDir();
-  let root = join(process.cwd(), src);
+  let root = join(COMMANDKIT_CWD, src);
 
-  if (!existsSync(root)) root = process.cwd();
+  if (!existsSync(root)) root = COMMANDKIT_CWD;
 
   currentDir = root;
 
@@ -43,7 +46,7 @@ export function getCurrentDirectory(): string {
 export function getSourceDirectories(): string[] {
   const dist = getConfig().distDir;
   const locations = ['src', '.commandkit', dist].map((dir) =>
-    join(process.cwd(), dir),
+    join(COMMANDKIT_CWD, dir),
   );
 
   return locations;
@@ -56,9 +59,9 @@ export function getSourceDirectories(): string[] {
 export function findAppDirectory(): string | null {
   if (appDir) return appDir;
 
-  let root = join(process.cwd(), getSrcDir());
+  let root = join(COMMANDKIT_CWD, getSrcDir());
 
-  if (!existsSync(root)) root = process.cwd();
+  if (!existsSync(root)) root = COMMANDKIT_CWD;
 
   const dirs = ['app'].map((dir) => join(root, dir));
 

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -19,6 +19,7 @@ import CommandKit, {
   CommandBuilderLike,
   CommandKitHMREvent,
   getCommandKit,
+  COMMANDKIT_CWD,
 } from 'commandkit';
 import FsBackend from 'i18next-fs-backend';
 import { basename, extname, join } from 'path';
@@ -298,7 +299,7 @@ export class I18nPlugin extends RuntimePlugin<LocalizationPluginOptions> {
     event: CommandKitHMREvent,
   ): Promise<void> {
     const targetLocation = event.path;
-    const localeDir = join(process.cwd(), '/src/app/locales');
+    const localeDir = join(COMMANDKIT_CWD, '/src/app/locales');
 
     if (!targetLocation.startsWith(localeDir)) return;
 

--- a/packages/legacy/src/cli.ts
+++ b/packages/legacy/src/cli.ts
@@ -1,4 +1,9 @@
-import { CompilerPlugin, CompilerPluginRuntime, Logger } from 'commandkit';
+import {
+  COMMANDKIT_CWD,
+  CompilerPlugin,
+  CompilerPluginRuntime,
+  Logger,
+} from 'commandkit';
 import { LegacyHandlerPluginOptions } from './plugin.js';
 import { join } from 'path';
 import { existsSync, mkdirSync } from 'fs';
@@ -74,7 +79,7 @@ export async function run({ interaction }: SlashCommandProps) {
       this.panic(message);
     }
 
-    const isTypeScript = existsSync(join(process.cwd(), 'tsconfig.json'));
+    const isTypeScript = existsSync(join(COMMANDKIT_CWD, 'tsconfig.json'));
     const extension = isTypeScript ? 'ts' : 'js';
 
     const [type, name] = args;
@@ -82,7 +87,7 @@ export async function run({ interaction }: SlashCommandProps) {
     switch (type) {
       case 'command': {
         const commandPath = join(
-          process.cwd(),
+          COMMANDKIT_CWD,
           'src',
           this.options.commandsPath,
           `${name}.${extension}`,
@@ -101,7 +106,7 @@ export async function run({ interaction }: SlashCommandProps) {
       case 'event': {
         let fileName = `${name}.${extension}`;
         const eventPathDir = join(
-          process.cwd(),
+          COMMANDKIT_CWD,
           'src',
           this.options.eventsPath,
           name,


### PR DESCRIPTION
- Added COMMANDKIT_CWD constant to centralize the current working directory across the codebase.
- Updated various modules to use COMMANDKIT_CWD instead of process.cwd() for improved consistency and maintainability.
