### PR TITLE
Fix task plugin cannot run dynamic tasks after the first task created

### DIFF
--- a/packages/tasks/src/drivers/bullmq.ts
+++ b/packages/tasks/src/drivers/bullmq.ts
@@ -80,7 +80,7 @@ export class BullMQDriver implements TaskDriver {
    * @returns A unique job identifier
    */
   public async create(task: TaskData): Promise<string> {
-    const taskId = `${task.name}-${typeof task.schedule === 'string' ? 'scheduled' : 'delayed'}`;
+    const taskId = `${task.name}-${typeof task.schedule === 'string' ? 'scheduled' : crypto.randomUUID()}`;
     const job = await this.queue.add(task.name, task.data, {
       ...(typeof task.schedule === 'string'
         ? {
@@ -97,10 +97,8 @@ export class BullMQDriver implements TaskDriver {
                 : task.schedule) - Date.now(),
           }),
       jobId: taskId,
-      deduplication: {
-        id: taskId,
-        replace: true,
-      },
+      removeOnComplete: true,
+      removeOnFail: true,
     });
 
     return job.id ?? taskId;


### PR DESCRIPTION
Fix #604 

## Implementation
1. Removed deduplication option in BullMQ, since it do not match the use case here.
1. Changed the fixed id of BullMQ dynamic task into a random uuid.
1. Added `removeOnComplete` and `removeOnFail` option to prevent Redis use up all the memory because of the completed job keep forever.